### PR TITLE
Open shm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ impl FDP {
         let libfdp = unsafe { LibFDP::new() };
         // create SHM
         info!("create SHM {}", vm_name);
-        let shm = (libfdp.create_shm)(c_vm_name.into_raw());
+        let shm = (libfdp.open_shm)(c_vm_name.into_raw());
 
         // init FDP
         info!("initialize FDP");

--- a/src/libfdp.rs
+++ b/src/libfdp.rs
@@ -8,12 +8,14 @@ const LIBFDP_FILENAME: &'static str = "libFDP.so";
 // libFDP function signatures type alises
 // FDP_CreateSHM
 type FnCreateSHM = extern "C" fn(shm_name: *mut c_char) -> *mut FDP_SHM;
+// FDP_OpenSHM
+type FnOpenSHM = extern "C" fn(shm_name: *const ::std::os::raw::c_char) -> *mut FDP_SHM;
 // FDP_Init
-type FnInit = extern "C" fn(pShm: *mut FDP_SHM) -> bool;
+type FnInit = extern "C" fn(p_shm: *mut FDP_SHM) -> bool;
 // FDP_Pause
-type FnPause = extern "C" fn(pShm: *mut FDP_SHM) -> bool;
+type FnPause = extern "C" fn(p_shm: *mut FDP_SHM) -> bool;
 // FDP_Resume
-type FnResume = extern "C" fn(pShm: *mut FDP_SHM) -> bool;
+type FnResume = extern "C" fn(p_shm: *mut FDP_SHM) -> bool;
 // FDP_ReadPhysicalMemory
 type FnReadPhysicalMemory = extern "C" fn(
     p_shm: *mut FDP_SHM,
@@ -29,6 +31,7 @@ type FnGetPhysicalMemorySize =
 pub struct LibFDP {
     lib: Library,
     pub create_shm: RawSymbol<FnCreateSHM>,
+    pub open_shm: RawSymbol<FnOpenSHM>,
     pub init: RawSymbol<FnInit>,
     pub pause: RawSymbol<FnPause>,
     pub resume: RawSymbol<FnResume>,
@@ -43,6 +46,9 @@ impl LibFDP {
         // load symbols
         let create_shm_sym: Symbol<FnCreateSHM> = lib.get(b"FDP_CreateSHM\0").unwrap();
         let create_shm = create_shm_sym.into_raw();
+
+        let open_shm_sym: Symbol<FnOpenSHM> = lib.get(b"FDP_OpenSHM\0").unwrap();
+        let open_shm = open_shm_sym.into_raw();
 
         let init_sym: Symbol<FnInit> = lib.get(b"FDP_Init\0").unwrap();
         let init = init_sym.into_raw();
@@ -64,6 +70,7 @@ impl LibFDP {
         LibFDP {
             lib,
             create_shm,
+            open_shm,
             init,
             pause,
             resume,


### PR DESCRIPTION
Using `FDP_CreateSHM` leads to the internal struct `FDP_CPU_CTX` not being initialized:

C source:
![Capture d’écran de 2020-08-23 23-29-12](https://user-images.githubusercontent.com/964610/90989526-b43f6800-e59a-11ea-899c-94c10e8311ad.png)

crash:
![Capture d’écran de 2020-08-23 23-28-26](https://user-images.githubusercontent.com/964610/90989530-bacddf80-e59a-11ea-8587-edc51282e792.png)

Apprently, even `Icebox` projects doesn't really use this API:
https://github.com/thalium/icebox/search?q=FDP_CreateSHM&unscoped_q=FDP_CreateSHM

Switch to `FDP_OpenSHM`, which takes care of initializing the CPU state, among other things.
Here, `FDP_ReadRegister` doesn't segfault
![Capture d’écran de 2020-08-23 23-46-26](https://user-images.githubusercontent.com/964610/90989559-e781f700-e59a-11ea-98fb-fd4a9ed89263.png)
