### PR TITLE
fix LIBFDP_BASENAME when using libloading::library_filename

### DIFF
--- a/src/libfdp.rs
+++ b/src/libfdp.rs
@@ -8,7 +8,7 @@ use libloading::os::windows::Symbol as RawSymbol;
 use libloading::{library_filename, Library, Symbol};
 use std::error::Error;
 
-const LIBFDP_BASENAME: &str = "libFDP";
+const LIBFDP_BASENAME: &str = "FDP";
 // libFDP function signatures type alises
 // FDP_CreateSHM
 type FnCreateSHM = extern "C" fn(shm_name: *mut c_char) -> *mut FDP_SHM;


### PR DESCRIPTION
We use [`library_filename`](https://docs.rs/libloading/0.7.0/libloading/fn.library_filename.html) which already appends `lib` prefix to the library basename.

Bug inserted by https://github.com/Wenzel/fdp/pull/15